### PR TITLE
Add libheif DLLs for Windows and add github action builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,87 @@
+name: Build executables
+on:
+  push:
+    branches: [ master, develop, build ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build-ubuntu22:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+        python_versions: ['3.7', '3.8', '3.9', '3.10']
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python_versions }}
+          cache: 'pip'
+          architecture: 'x64'
+
+      - name: Install python requirements
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -r requirements.txt --upgrade
+
+      - name: Install apt requirements
+        run: | 
+          sudo apt update
+          sudo apt install libheif1 libheif-dev -y
+
+      - name: Build wheel
+        run: | 
+          python setup.py bdist_wheel --use-cython
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v3
+        with:
+          name: cyheif
+          path: dist/*.whl
+
+
+  build-windows-2019:
+
+    runs-on: windows-2019
+
+    strategy:
+      matrix:
+        python_versions: ['3.7', '3.8', '3.9', '3.10']
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python_versions }}
+          cache: 'pip'
+          architecture: 'x64'
+
+      - name: Install python requirements
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -r requirements.txt --upgrade
+
+      - uses: friendlyanon/setup-vcpkg@v1
+        with:
+          committish: f93ba152d55e1d243160e690bc302ffe8638358e
+          cache-key: vcpkg-py${{ matrix.python_versions }}-f93ba
+          cache-restore-keys: vcpkg-py${{ matrix.python_versions }}-
+          path: vcpkg
+
+      - name: Build libheif
+        run: |
+          vcpkg\vcpkg.exe install libheif --triplet x64-windows
+
+      - name: Build wheel
+        run: |
+          python setup.py bdist_wheel --use-cython
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v3
+        with:
+          name: cyheif
+          path: dist/*.whl

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Ramkumar Natarajan
+Copyright (c) 2022 Ramkumar Natarajan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -14,6 +14,29 @@ Supports the following:
 - Writing a Pillow Image out as a HEIC file
 - Use Pillow functionality for other image manipulations - resize, transforms etc.
 
+Examples
+--------
+
+Import heif file into a PIL image
+
+```python
+from cyheifloader import cyheif
+
+img = cyheif.get_pil_image("my_heif_file.heic".encode()) # Filename must be in bytes
+# Now can use `img` as if you ran Image.open() from PIL or pillow 
+```
+
+View EXIF data
+
+```python 
+from cyheifloader import cyheif
+
+exif = cyheif.get_exif_data("my_heif_file.heif".encode())
+exif_readable = {TAGS.get(k):v for (k, v) in exif.items()}
+print(exif_readable)
+```
+
+
 Known Issues
 ------------
 No Documentation - working on it. No binary distributions yet - help welcome to create these. See example/run.py for usage of key functionality.
@@ -33,7 +56,7 @@ More details on [vcpkg is available here.](https://docs.microsoft.com/en-us/cpp/
 On Linux, Ubuntu based distributions can install libheif and libheif-dev with the following commands:
 
 ```
-sudo apt install libheif
+sudo apt install libheif1
 sudo apt install libheif-dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,17 @@ from cyheifloader import cyheif
 
 img = cyheif.get_pil_image("my_heif_file.heic".encode()) # Filename must be in bytes
 # Now can use `img` as if you ran Image.open() from PIL or pillow 
+
+img.thumbnail((256, 256))
+
+# Need to use cyheif to write back to heif files, or can use img.save if using another supported image format 
+cyheif.write_pil_image(img, b"thumb.heif")
 ```
 
 View EXIF data
 
 ```python 
+from PIL.ExifTags import TAGS
 from cyheifloader import cyheif
 
 exif = cyheif.get_exif_data("my_heif_file.heif".encode())

--- a/cyheifloader/__init__.py
+++ b/cyheifloader/__init__.py
@@ -3,7 +3,7 @@ import sys
 if sys.platform.startswith('win32'):
     import os
 
-    libheif_path = os.getenv('LIBHEIF_PATH', 'C:/vcpkg/installed/x64-windows/bin')
+    libheif_path = os.getenv('LIBHEIF_PATH', os.path.join(sys.prefix, 'bin'))
 
     with os.add_dll_directory(libheif_path):
         import cyheif

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,11 @@ import sys
 import os
 import argparse
 
+default_vcpkg_root = os.getenv("VCPKG_ROOT", "C:/vcpkg")
+
 argparser = argparse.ArgumentParser(add_help=False)
 argparser.add_argument('--use-cython', action='store_true', default=False)
-argparser.add_argument('--libheif_path', default='C:/vcpkg/installed/x64-windows')
+argparser.add_argument('--libheif_path', default=f"{default_vcpkg_root}/installed/x64-windows")
 args, unknown = argparser.parse_known_args()
 sys.argv = [sys.argv[0]] + unknown
 
@@ -45,7 +47,7 @@ if args.use_cython:
 
 setup(
     name='cyheif',
-    version='0.0.5',
+    version='0.0.6',
     description='Python wrapper for libheif',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -54,5 +56,7 @@ setup(
     keywords='libheif, heif, heic, high-efficiency image format',
     python_requires='>=3.6',
     ext_modules=extensions,
-    packages=['cyheifloader']
+    packages=['cyheifloader'],
+    install_requires=['pillow'],
+    data_files=[('bin', [str(x.absolute()) for x in pathlib.Path(lib_dirs[0]).glob("*.dll")])] if sys.platform.startswith('win32') else [],
 )

--- a/setup.py
+++ b/setup.py
@@ -20,12 +20,15 @@ long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 lib_dirs = []
 inc_dirs = []
+bin_files = []
 if sys.platform.startswith('win32'):
+    required_dlls = ("heif.dll", "libde265.dll", "libx265.dll")
     libheif_bin_path = os.path.join(args.libheif_path, 'bin')
     libheif_lib_path = os.path.join(args.libheif_path, 'lib')
     libheif_inc_path = os.path.join(args.libheif_path, 'include')
     lib_dirs = [libheif_bin_path, libheif_lib_path]
     inc_dirs = [libheif_inc_path]
+    bin_files = [str(x.absolute()) for x in pathlib.Path(libheif_bin_path).glob("*") if x.name in required_dlls]
 
 ext = '.pyx' if args.use_cython else '.c'
 
@@ -58,5 +61,5 @@ setup(
     ext_modules=extensions,
     packages=['cyheifloader'],
     install_requires=['pillow'],
-    data_files=[('bin', [str(x.absolute()) for x in pathlib.Path(lib_dirs[0]).glob("*.dll")])] if sys.platform.startswith('win32') else [],
+    data_files=[('bin', bin_files)] if sys.platform.startswith('win32') else [],
 )


### PR DESCRIPTION
The ultimate goal is for users to be able to `pip install cyheif` from `pypi` without needing any other steps and be able to use the program right away.  That is more difficult on linux (requires `libheif1` installed), but we can do that with Windows at least. 

This PR adds builds for 3.7-3.10 on Ubuntu and Windows. It produces a zip file with the 8 different `.whl` files that can be uploaded to PYPI with each release. 

This also puts the heif DLL generated on Windows into the wheel to make it portable. (the libheif library looks to be LGPL licensed so shouldn't have any issues there from my knowledge.) 

A good follow up to this PR would be to create a "release" workflow that would auto push to pypi when creating/tagging a release in github. 

The first run of the actions will take ~10 minutes for the libheif build, but are cached after that and then take about ~2 minutes. 

Resolves #3 

Tested on 3.10 on Windows and WSL Ubuntu 22 